### PR TITLE
Change remaining / to math.div

### DIFF
--- a/styles/utilities/functions.sass
+++ b/styles/utilities/functions.sass
@@ -1,3 +1,5 @@
+@use "sass:math"
+
 @function mergeColorMaps($bulma-colors, $custom-colors)
   // we return at least bulma hardcoded colors
   $merged-colors: $bulma-colors
@@ -39,18 +41,18 @@
       $value: $value * $number
   @else if $exp < 0
     @for $i from 1 through -$exp
-      $value: $value / $number
+      $value: math.div($value, $number)
   @return $value
 
 @function colorLuminance($color)
   $color-rgb: ('red': red($color),'green': green($color),'blue': blue($color))
   @each $name, $value in $color-rgb
     $adjusted: 0
-    $value: $value / 255
+    $value: math.div($value, 255)
     @if $value < 0.03928
-      $value: $value / 12.92
+      $value: math.div($value, 12.92)
     @else
-      $value: ($value + .055) / 1.055
+      $value: math.div($value + .055, 1.055)
       $value: powerNumber($value, 2)
     $color-rgb: map-merge($color-rgb, ($name: $value))
   @return (map-get($color-rgb, 'red') * .2126) + (map-get($color-rgb, 'green') * .7152) + (map-get($color-rgb, 'blue') * .0722)


### PR DESCRIPTION
Following the very helpful changes by @mofe23 in #52, there were 4 instances left of a `/` being used outside of `calc()`. This PR replaces them with calls to `math.div()` [as recommended in the official documentation](https://sass-lang.com/documentation/breaking-changes/slash-div).

Let me know if you have any questions!